### PR TITLE
MPI working, more command line argument handling

### DIFF
--- a/src/TimeIntegrator.hpp
+++ b/src/TimeIntegrator.hpp
@@ -42,7 +42,7 @@ void rk3(const double x0[NumSpaceDims],
     double v0[NumSpaceDims], 
            x1[NumSpaceDims], v1[NumSpaceDims],
 	   x2[NumSpaceDims], v2[NumSpaceDims]; 
-
+    
     // Velocity at current location.
     Interpolation::interpolateVelocity<NumSpaceDims, 1>(x0, local_mesh, u, v, v0);
 

--- a/src/VelocityCorrector.hpp
+++ b/src/VelocityCorrector.hpp
@@ -73,6 +73,8 @@ class VelocityCorrector<2, ExecutionSpace, MemorySpace, SparseSolver> : public V
 						    vector_layout);
     _rhs = Cajita::createArray<double, MemorySpace>("pressure RHS",
 						    vector_layout);
+    Cajita::ArrayOp::assign(*_lhs, 0.0, Cajita::Ghost());
+    Cajita::ArrayOp::assign(*_rhs, 0.0, Cajita::Ghost());
 
     // Set up the solver to compute the pressure at each point using a 5-point 
     // 2d laplacian stencil. The matrix itself will have 0 weights for elements


### PR DESCRIPTION
Switched to Hypre PCG with Jacobi preconditioner as default, added some extra
initialization to make sure things are working properly for general bulletproofing.
MPI appears to work but breaks with some of the more aggressive HYPRE solvers
(e.g. PFMG) for reasons that still aren't clear but feel like memory corruption. 
Should turn off I/O and see if this goes away as it may be related to the I/O LayoutRight 
vs. LayoutLeft issue.